### PR TITLE
Feature/#3 deploy sttings

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -11,6 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Create .env File
+        shell: bash
+        run: |
+          touch .env
+          echo "REACT_APP_OPENAI_API_KEY=${{ secrets.REACT_APP_OPENAI_API_KEY }}" >> .env
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
       - name: Pull Vercel Environment Information

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+.vercel

--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,7 @@ function App() {
         <p>
           Edit <code>src/App.js</code> and save to reload.
         </p>
+        <p>デプロイテスト用のテキスト</p>
         <p>{text ? text : 'ここにテキストが書かれます'}</p>
         <StopButton handleClick={handleClick} />
       </header>


### PR DESCRIPTION
## 概要
Vercelの組織IDやプロジェクトIDが記述されている.vercelファイルをgit管理対象外にする
workflowに.envファイルを作成する処理を追加

## 対応の詳細

1. 以下の記事を参考に、workflowに処理を追加
https://zenn.dev/big_tanukiudon/articles/fc1a2ff562ce3d

2. secretsを追加
https://github.com/Apocalyptic-Wonderboiled/wonder-app/settings/secrets/actions

## レビュー観点
1.で参考にした記事内の - shell の -は不要そうなので外していますが、外して問題ないか確証はないです。
以下の記事のサンプルを参照して不要だと判断しました。
https://qiita.com/HeRo/items/935d5e268208d411ab5a
そもそもshell: bashの記述も不要かもしれません。

## その他
公式ドキュメント（すみません、読み込めてません）
https://docs.github.com/ja/actions/using-workflows/about-workflows