### PR TITLE
stateが更新されない件の仮実装

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,14 +2,19 @@ import logo from './logo.svg';
 import './App.css';
 import { useChatGpt } from './hooks/useChatGpt';
 import { StopButton } from './components/StopButton';
-import { TestPrefectureButton } from './components/TestPrefectureButton';
 import { useRandomPrefecture } from './hooks/useRandomPrefecture';
+import { useEffect } from 'react';
 
 function App() {
   const [text, getReply] = useChatGpt();
-  const handleClick = () => getReply();
   const [prefecture, getPrefecture] = useRandomPrefecture();
-  const handleClick2 = () => getPrefecture();
+  const handleClick = () => getPrefecture();
+
+  useEffect(() => {
+    if (!prefecture) return;
+
+    getReply(prefecture.romaji);
+  }, [prefecture]);
 
   return (
     <div className="App">
@@ -21,9 +26,6 @@ function App() {
         <p>デプロイテスト用のテキスト</p>
         <p>{text ? text : 'ここにテキストが書かれます'}</p>
         <StopButton handleClick={handleClick} />
-        <p>{prefecture ? prefecture.kanji : '都道府県'}</p>
-        <p>{prefecture ? prefecture.romaji : 'todoufuken'}</p>
-        <TestPrefectureButton handleClick={handleClick2} />
       </header>
     </div>
   );

--- a/src/hooks/useChatGpt.js
+++ b/src/hooks/useChatGpt.js
@@ -4,10 +4,10 @@ import { Client } from '../api/client';
 export const useChatGpt = () => {
   const [text, setText] = useState(null);
 
-  const getReply = async () => {
+  const getReply = async (prefecture) => {
     try {
       setText('ローディング中...'); // 仮で文字列にしておく。TODO：booleanの状態変化するuseStateを実装してローディングのコンポーネントをtrue/falseで表示するようにする
-      const client = new Client('Hiroshima');
+      const client = new Client(prefecture);
       const response = await client.execute();
       setText(response);
     } catch (error) {

--- a/src/mocks/browser.js
+++ b/src/mocks/browser.js
@@ -4,7 +4,7 @@ import prefectures from '../data/prefectures.json';
 export const worker = setupWorker(
   rest.post('/v1/chat/completions', (req, res, ctx) => {
     const pattern = new RegExp(`^${req.body}$`);
-    const isVerified = prefectures.some((prefecture) => pattern.test(prefecture));
+    const isVerified = prefectures.some((prefecture) => pattern.test(prefecture.romaji));
 
     if (!isVerified) {
       return res(


### PR DESCRIPTION
> **なぜセットした値が更新されていないのか？**
なぜセットした値が更新されていないのかというと、setStateで値が更新されるのは関数が呼び出された後だからです。

参考：https://zenn.dev/syu/articles/3c4aa813b57b8c

なので、useEffectを使って、prefectureの値が変わったことを検知してgetReplyを実行するようにしました


もしくは、getPrefectureではstateの更新とかやらないでそのままprefectures[randomIndex]を返すようにしても実装できそう。ただ、その場合はstateの保持とかはできない。