### PR TITLE
ボタンの統合 #18

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,15 +1,25 @@
 import logo from './logo.svg';
 import './App.css';
 import { useChatGpt } from './hooks/useChatGpt';
-import { StopButton } from './components/StopButton';
-import { TestPrefectureButton } from './components/TestPrefectureButton';
+import { StartStopButton } from './components/StartStopButton';
 import { useRandomPrefecture } from './hooks/useRandomPrefecture';
+import { useState, useEffect } from 'react';
 
 function App() {
   const [text, getReply] = useChatGpt();
-  const handleClick = () => getReply();
   const [prefecture, getPrefecture] = useRandomPrefecture();
-  const handleClick2 = () => getPrefecture();
+  const [isButtonClicked, setIsButtonClicked] = useState(true);
+
+  const handleClick = () => {
+    setIsButtonClicked(!isButtonClicked);
+    if (isButtonClicked) return;
+    getPrefecture();
+  };
+
+  useEffect(() => {
+    if (!prefecture) return;
+    getReply(prefecture.romaji);
+  }, [prefecture]);
 
   return (
     <div className="App">
@@ -19,11 +29,8 @@ function App() {
           Edit <code>src/App.js</code> and save to reload.
         </p>
         <p>デプロイテスト用のテキスト</p>
-        <p>{text ? text : 'ここにテキストが書かれます'}</p>
-        <StopButton handleClick={handleClick} />
-        <p>{prefecture ? prefecture.kanji : '都道府県'}</p>
-        <p>{prefecture ? prefecture.romaji : 'todoufuken'}</p>
-        <TestPrefectureButton handleClick={handleClick2} />
+        <p>{text && isButtonClicked ? text : 'ここにテキストが書かれます'}</p>
+        <StartStopButton handleClick={handleClick} text={isButtonClicked ? 'はじめる' : 'STOP'} />
       </header>
     </div>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -9,11 +9,16 @@ function App() {
   const [text, getReply] = useChatGpt();
   const [prefecture, getPrefecture] = useRandomPrefecture();
   const [isButtonClicked, setIsButtonClicked] = useState(true);
+  const [isTopPage, setIsTopPage] = useState(true);
 
   const handleClick = () => {
-    setIsButtonClicked(!isButtonClicked);
-    if (isButtonClicked) return;
+    if (isTopPage) return;
     getPrefecture();
+    setIsTopPage(true);
+  };
+
+  const linkDecidePrefecturePage = () => {
+    setIsTopPage(false);
   };
 
   useEffect(() => {
@@ -29,8 +34,11 @@ function App() {
           Edit <code>src/App.js</code> and save to reload.
         </p>
         <p>デプロイテスト用のテキスト</p>
-        <p>{text && isButtonClicked ? text : 'ここにテキストが書かれます'}</p>
-        <StartStopButton handleClick={handleClick} text={isButtonClicked ? 'はじめる' : 'STOP'} />
+        <p>{text && isTopPage ? text : 'ここにテキストが書かれます'}</p>
+        <StartStopButton
+          handleClick={isTopPage ? linkDecidePrefecturePage : handleClick}
+          text={isTopPage ? 'はじめる' : 'STOP'}
+        />
       </header>
     </div>
   );

--- a/src/App.js
+++ b/src/App.js
@@ -8,7 +8,6 @@ import { useState, useEffect } from 'react';
 function App() {
   const [text, getReply] = useChatGpt();
   const [prefecture, getPrefecture] = useRandomPrefecture();
-  const [isButtonClicked, setIsButtonClicked] = useState(true);
   const [isTopPage, setIsTopPage] = useState(true);
 
   const handleClick = () => {
@@ -17,9 +16,7 @@ function App() {
     setIsTopPage(true);
   };
 
-  const linkDecidePrefecturePage = () => {
-    setIsTopPage(false);
-  };
+  const linkDecidePrefecturePage = () => setIsTopPage(false);
 
   useEffect(() => {
     if (!prefecture) return;

--- a/src/components/StartStopButton.jsx
+++ b/src/components/StartStopButton.jsx
@@ -1,9 +1,9 @@
 import Button from '@mui/material/Button';
 
-export const TestPrefectureButton = (props) => {
+export const StartStopButton = (props) => {
   return (
     <Button variant="contained" onClick={props.handleClick}>
-      ランダム都道府県
+      {props.text}
     </Button>
   );
 };

--- a/src/components/StopButton.jsx
+++ b/src/components/StopButton.jsx
@@ -1,9 +1,0 @@
-import Button from '@mui/material/Button';
-
-export const StopButton = (props) => {
-  return (
-    <Button variant="contained" onClick={props.handleClick}>
-      APIリクエスト実行！
-    </Button>
-  );
-};

--- a/src/hooks/useChatGpt.js
+++ b/src/hooks/useChatGpt.js
@@ -4,10 +4,10 @@ import { Client } from '../api/client';
 export const useChatGpt = () => {
   const [text, setText] = useState(null);
 
-  const getReply = async () => {
+  const getReply = async (prefecture) => {
     try {
       setText('ローディング中...'); // 仮で文字列にしておく。TODO：booleanの状態変化するuseStateを実装してローディングのコンポーネントをtrue/falseで表示するようにする
-      const client = new Client('Hiroshima');
+      const client = new Client(prefecture);
       const response = await client.execute();
       setText(response);
     } catch (error) {

--- a/src/mocks/browser.js
+++ b/src/mocks/browser.js
@@ -20,7 +20,7 @@ export const worker = setupWorker(
       ctx.status(200),
       ctx.delay(1000),
       ctx.json({
-        content: `都道府県名：${JSON.stringify(req.body)}
+        content: `都道府県名：${req.body}
         広島県には魅力的な観光地がたくさんあります。以下はおすすめの旅行先です。
 
         1. 広島平和記念公園と原爆ドーム: 第二次世界大戦で被爆した広島市にある平和祈念の地です。平和記念資料館もあり、歴史の学びと平和への思いを感じることができます。

--- a/src/mocks/browser.js
+++ b/src/mocks/browser.js
@@ -4,7 +4,7 @@ import prefectures from '../data/prefectures.json';
 export const worker = setupWorker(
   rest.post('/v1/chat/completions', (req, res, ctx) => {
     const pattern = new RegExp(`^${req.body}$`);
-    const isVerified = prefectures.some((prefecture) => pattern.test(prefecture));
+    const isVerified = prefectures.some((prefecture) => pattern.test(prefecture.romaji));
 
     if (!isVerified) {
       return res(
@@ -20,7 +20,8 @@ export const worker = setupWorker(
       ctx.status(200),
       ctx.delay(1000),
       ctx.json({
-        content: `広島県には魅力的な観光地がたくさんあります。以下はおすすめの旅行先です。
+        content: `都道府県名：${JSON.stringify(req.body)}
+        広島県には魅力的な観光地がたくさんあります。以下はおすすめの旅行先です。
 
         1. 広島平和記念公園と原爆ドーム: 第二次世界大戦で被爆した広島市にある平和祈念の地です。平和記念資料館もあり、歴史の学びと平和への思いを感じることができます。
         


### PR DESCRIPTION
## 概要
<!-- 
(例)ユーザ画面の 〇〇 機能を ×× に修正
(例)新規機能 △△ を実装
-->
#18 複数のボタンを1つに統合した。

## 対応の詳細
<!-- どのように実装したかを簡潔に書いてね -->
- gptへのリクエストと都道府県取得処理を統合
　確認用でモックのレスポンスに取得した県を追記

- ボタンの表示を切り替え
　はじめる：何もしない(シャッフルアニメーション表示想定)
　STOP：gptにリクエスト、内容表示

## レビュー観点
<!-- このPRで見て欲しいところを書いてね -->
ボタンの挙動が想定通りか

## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->
- ボタン名は一旦デザインベースにしたが、ひらがなか英語か統一しても良さそう。
- コメントしたhandleClickのところはわかりやすい書き方あれば教えてほしいです。