### PR TITLE
#3 mainブランチにpushした際に、vercel本番環境へ反映するworkflowを作成

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,26 @@
+name: Vercel Production Deployment
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+on:
+  push:
+    branches:
+      - main
+jobs:
+  Deploy-Production:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Create .env File
+        shell: bash
+        run: |
+          touch .env
+          echo "REACT_APP_OPENAI_API_KEY=${{ secrets.REACT_APP_OPENAI_API_KEY }}" >> .env
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+      - name: Pull Vercel Environment Information
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Build Project Artifacts
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+      - name: Deploy Project Artifacts to Vercel
+        run: vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## 概要
vercel本番環境へ反映するworkflowを作成

## 対応の詳細
main.ymlを作成
preview.ymlとの差分は、branches-ignore: が branches: となっている。
これにより、main ブランチにpushされた際に、workflowが起動しVercelのProduction Deploymentに反映される。

以下を参考
https://vercel.com/guides/how-can-i-use-github-actions-with-vercel

## レビュー観点
typoなどがないか、上記以外に環境ごとに分ける必要があるものがあればご指摘ください。

## その他
