### PR TITLE
chatgptにリクエストしている最中のロード中UIの実装 #16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
-        "@mui/material": "^5.14.4",
+        "@mui/icons-material": "^5.14.8",
+        "@mui/material": "^5.14.8",
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
@@ -1971,15 +1972,20 @@
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
     "node_modules/@babel/runtime": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
-      "integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.15.tgz",
+      "integrity": "sha512-T0O+aa+4w0u06iNmapipJXMV4HoUir03hpx3/YqXXhu9xim3w+dVphjFWl1OH8NbZHw5Lbm9k45drDkgq2VNNA==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.11"
+        "regenerator-runtime": "^0.14.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+      "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
     },
     "node_modules/@babel/template": {
       "version": "7.22.5",
@@ -2546,6 +2552,40 @@
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.4.1.tgz",
+      "integrity": "sha512-jk3WqquEJRlcyu7997NtR5PibI+y5bi+LS3hPmguVClypenMsCY3CBa3LAQnozRCtCrYWSEtAdiskpamuJRFOQ==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.1.1"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.1.tgz",
+      "integrity": "sha512-KwvVcPSXg6mQygvA1TjbN/gh///36kKtllIF8SUm0qpFj8+rvYrpvlYdL1JoA71SHpDqgSSdGOSoQ0Mp3uY5aw==",
+      "dependencies": {
+        "@floating-ui/core": "^1.4.1",
+        "@floating-ui/utils": "^0.1.1"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.2.tgz",
+      "integrity": "sha512-5qhlDvjaLmAst/rKb3VdlCinwTF4EYMiVxuuc/HVUjs46W0zgtbMmAZ1UTsDrRTxRmUEzl92mOtWbeeXL26lSQ==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.5.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.1.tgz",
+      "integrity": "sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.10",
@@ -3363,14 +3403,15 @@
       }
     },
     "node_modules/@mui/base": {
-      "version": "5.0.0-beta.10",
-      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.10.tgz",
-      "integrity": "sha512-moTAhGwFfQffj7hsu61FnqcGqVcd53A1CrOhnskM9TF0Uh2rnLDMCuar4JRUWWpaJofAfQEbQBBFPadFQLI4PA==",
+      "version": "5.0.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.14.tgz",
+      "integrity": "sha512-Je/9JzzYObsuLCIClgE8XvXNFb55IEz8n2NtStUfASfNiVrwiR8t6VVFFuhofehkyTIN34tq1qbBaOjCnOovBw==",
       "dependencies": {
-        "@babel/runtime": "^7.22.6",
+        "@babel/runtime": "^7.22.10",
         "@emotion/is-prop-valid": "^1.2.1",
+        "@floating-ui/react-dom": "^2.0.1",
         "@mui/types": "^7.2.4",
-        "@mui/utils": "^5.14.4",
+        "@mui/utils": "^5.14.8",
         "@popperjs/core": "^2.11.8",
         "clsx": "^2.0.0",
         "prop-types": "^15.8.1",
@@ -3400,25 +3441,50 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/@mui/core-downloads-tracker": {
-      "version": "5.14.4",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.14.4.tgz",
-      "integrity": "sha512-pW2XghSi3hpYKX57Wu0SCWMTSpzvXZmmucj3TcOJWaCiFt4xr05w2gcwBZi36dAp9uvd9//9N51qbblmnD+GPg==",
+      "version": "5.14.8",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.14.8.tgz",
+      "integrity": "sha512-8V7ZOC/lKkM03TRHqaThQFIq6bWPnj7L/ZWPh0ymldYFFyh8XdF0ywTgafsofDNYT4StlNknbaTjVHBma3SNjQ==",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui"
       }
     },
-    "node_modules/@mui/material": {
-      "version": "5.14.4",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.14.4.tgz",
-      "integrity": "sha512-2XUV3KyRC07BQPPzEgd+ss3x/ezXtHeKtOGCMCNmx3MauZojPYUpSwFkE0fYgYCD9dMQMVG4DY/VF38P0KShsg==",
+    "node_modules/@mui/icons-material": {
+      "version": "5.14.8",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.14.8.tgz",
+      "integrity": "sha512-YXcReLydTuNWb1/PxduAH5LgnHNH6spSQBaA0JOz9HD4J+vwst0IanAQgsXy9KKCJSjCsHywE3DB8X+w/b4eeQ==",
       "dependencies": {
-        "@babel/runtime": "^7.22.6",
-        "@mui/base": "5.0.0-beta.10",
-        "@mui/core-downloads-tracker": "^5.14.4",
-        "@mui/system": "^5.14.4",
+        "@babel/runtime": "^7.22.10"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/material": {
+      "version": "5.14.8",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.14.8.tgz",
+      "integrity": "sha512-fqvDGGF1pXwOOL/f0Gw+KHo/67hasRpf2ApTIJkbuONOk9AUb2jnYMEqCWmL2sUcbbE3ShMbHl8N7HPSsRv1/A==",
+      "dependencies": {
+        "@babel/runtime": "^7.22.10",
+        "@mui/base": "5.0.0-beta.14",
+        "@mui/core-downloads-tracker": "^5.14.8",
+        "@mui/system": "^5.14.8",
         "@mui/types": "^7.2.4",
-        "@mui/utils": "^5.14.4",
+        "@mui/utils": "^5.14.8",
         "@types/react-transition-group": "^4.4.6",
         "clsx": "^2.0.0",
         "csstype": "^3.1.2",
@@ -3458,12 +3524,12 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/@mui/private-theming": {
-      "version": "5.14.4",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.14.4.tgz",
-      "integrity": "sha512-ISXsHDiQ3z1XA4IuKn+iXDWvDjcz/UcQBiFZqtdoIsEBt8CB7wgdQf3LwcwqO81dl5ofg/vNQBEnXuKfZHrnYA==",
+      "version": "5.14.8",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.14.8.tgz",
+      "integrity": "sha512-iBzpcl3Mh92XaYpYPdgzzRxNGkjpoDz8rf8/q5m+EBPowFEHV+CCS9hC0Q2pOKLW3VFFikA7w/GHt7n++40JGQ==",
       "dependencies": {
-        "@babel/runtime": "^7.22.6",
-        "@mui/utils": "^5.14.4",
+        "@babel/runtime": "^7.22.10",
+        "@mui/utils": "^5.14.8",
         "prop-types": "^15.8.1"
       },
       "engines": {
@@ -3484,11 +3550,11 @@
       }
     },
     "node_modules/@mui/styled-engine": {
-      "version": "5.13.2",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.13.2.tgz",
-      "integrity": "sha512-VCYCU6xVtXOrIN8lcbuPmoG+u7FYuOERG++fpY74hPpEWkyFQG97F+/XfTQVYzlR2m7nPjnwVUgATcTCMEaMvw==",
+      "version": "5.14.8",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.14.8.tgz",
+      "integrity": "sha512-LGwOav/Y40PZWZ2yDk4beUoRlc57Vg+Vpxi9V9BBtT2ESAucCgFobkt+T8eVLMWF9huUou5pwKgLSU5pF90hBg==",
       "dependencies": {
-        "@babel/runtime": "^7.21.0",
+        "@babel/runtime": "^7.22.10",
         "@emotion/cache": "^11.11.0",
         "csstype": "^3.1.2",
         "prop-types": "^15.8.1"
@@ -3515,15 +3581,15 @@
       }
     },
     "node_modules/@mui/system": {
-      "version": "5.14.4",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.14.4.tgz",
-      "integrity": "sha512-oPgfWS97QNfHcDBapdkZIs4G5i85BJt69Hp6wbXF6s7vi3Evcmhdk8AbCRW6n0sX4vTj8oe0mh0RIm1G2A1KDA==",
+      "version": "5.14.8",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.14.8.tgz",
+      "integrity": "sha512-Dxnasv7Pj5hYe4ZZFKJZu4ufKm6cxpitWt3A+qMPps22YhqyeEqgDBq/HsAB3GOjqDP40fTAvQvS/Hguf4SJuw==",
       "dependencies": {
-        "@babel/runtime": "^7.22.6",
-        "@mui/private-theming": "^5.14.4",
-        "@mui/styled-engine": "^5.13.2",
+        "@babel/runtime": "^7.22.10",
+        "@mui/private-theming": "^5.14.8",
+        "@mui/styled-engine": "^5.14.8",
         "@mui/types": "^7.2.4",
-        "@mui/utils": "^5.14.4",
+        "@mui/utils": "^5.14.8",
         "clsx": "^2.0.0",
         "csstype": "^3.1.2",
         "prop-types": "^15.8.1"
@@ -3567,11 +3633,11 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "5.14.4",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.14.4.tgz",
-      "integrity": "sha512-4ANV0txPD3x0IcTCSEHKDWnsutg1K3m6Vz5IckkbLXVYu17oOZCVUdOKsb/txUmaCd0v0PmSRe5PW+Mlvns5dQ==",
+      "version": "5.14.8",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.14.8.tgz",
+      "integrity": "sha512-1Ls2FfyY2yVSz9NEqedh3J8JAbbZAnUWkOWLE2f4/Hc4T5UWHMfzBLLrCqExfqyfyU+uXYJPGeNIsky6f8Gh5Q==",
       "dependencies": {
-        "@babel/runtime": "^7.22.6",
+        "@babel/runtime": "^7.22.10",
         "@types/prop-types": "^15.7.5",
         "@types/react-is": "^18.2.1",
         "prop-types": "^15.8.1",
@@ -21182,11 +21248,18 @@
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
     "@babel/runtime": {
-      "version": "7.22.6",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.6.tgz",
-      "integrity": "sha512-wDb5pWm4WDdF6LFUde3Jl8WzPA+3ZbxYqkC6xAXuD3irdEHN1k0NfTRrJD8ZD378SJ61miMLCqIOXYhd8x+AJQ==",
+      "version": "7.22.15",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.15.tgz",
+      "integrity": "sha512-T0O+aa+4w0u06iNmapipJXMV4HoUir03hpx3/YqXXhu9xim3w+dVphjFWl1OH8NbZHw5Lbm9k45drDkgq2VNNA==",
       "requires": {
-        "regenerator-runtime": "^0.13.11"
+        "regenerator-runtime": "^0.14.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.14.0",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.0.tgz",
+          "integrity": "sha512-srw17NI0TUWHuGa5CFGGmhfNIeja30WMBfbslPNhf6JrqQlLN5gcrvig1oqPxiVaXb0oW0XRKtH6Nngs5lKCIA=="
+        }
       }
     },
     "@babel/template": {
@@ -21544,6 +21617,36 @@
       "version": "8.46.0",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.46.0.tgz",
       "integrity": "sha512-a8TLtmPi8xzPkCbp/OGFUo5yhRkHM2Ko9kOWP4znJr0WAhWyThaw3PnwX4vOTWOAMsV2uRt32PPDcEz63esSaA=="
+    },
+    "@floating-ui/core": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.4.1.tgz",
+      "integrity": "sha512-jk3WqquEJRlcyu7997NtR5PibI+y5bi+LS3hPmguVClypenMsCY3CBa3LAQnozRCtCrYWSEtAdiskpamuJRFOQ==",
+      "requires": {
+        "@floating-ui/utils": "^0.1.1"
+      }
+    },
+    "@floating-ui/dom": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.1.tgz",
+      "integrity": "sha512-KwvVcPSXg6mQygvA1TjbN/gh///36kKtllIF8SUm0qpFj8+rvYrpvlYdL1JoA71SHpDqgSSdGOSoQ0Mp3uY5aw==",
+      "requires": {
+        "@floating-ui/core": "^1.4.1",
+        "@floating-ui/utils": "^0.1.1"
+      }
+    },
+    "@floating-ui/react-dom": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.2.tgz",
+      "integrity": "sha512-5qhlDvjaLmAst/rKb3VdlCinwTF4EYMiVxuuc/HVUjs46W0zgtbMmAZ1UTsDrRTxRmUEzl92mOtWbeeXL26lSQ==",
+      "requires": {
+        "@floating-ui/dom": "^1.5.1"
+      }
+    },
+    "@floating-ui/utils": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.1.tgz",
+      "integrity": "sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw=="
     },
     "@humanwhocodes/config-array": {
       "version": "0.11.10",
@@ -22160,14 +22263,15 @@
       }
     },
     "@mui/base": {
-      "version": "5.0.0-beta.10",
-      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.10.tgz",
-      "integrity": "sha512-moTAhGwFfQffj7hsu61FnqcGqVcd53A1CrOhnskM9TF0Uh2rnLDMCuar4JRUWWpaJofAfQEbQBBFPadFQLI4PA==",
+      "version": "5.0.0-beta.14",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.14.tgz",
+      "integrity": "sha512-Je/9JzzYObsuLCIClgE8XvXNFb55IEz8n2NtStUfASfNiVrwiR8t6VVFFuhofehkyTIN34tq1qbBaOjCnOovBw==",
       "requires": {
-        "@babel/runtime": "^7.22.6",
+        "@babel/runtime": "^7.22.10",
         "@emotion/is-prop-valid": "^1.2.1",
+        "@floating-ui/react-dom": "^2.0.1",
         "@mui/types": "^7.2.4",
-        "@mui/utils": "^5.14.4",
+        "@mui/utils": "^5.14.8",
         "@popperjs/core": "^2.11.8",
         "clsx": "^2.0.0",
         "prop-types": "^15.8.1",
@@ -22182,21 +22286,29 @@
       }
     },
     "@mui/core-downloads-tracker": {
-      "version": "5.14.4",
-      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.14.4.tgz",
-      "integrity": "sha512-pW2XghSi3hpYKX57Wu0SCWMTSpzvXZmmucj3TcOJWaCiFt4xr05w2gcwBZi36dAp9uvd9//9N51qbblmnD+GPg=="
+      "version": "5.14.8",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.14.8.tgz",
+      "integrity": "sha512-8V7ZOC/lKkM03TRHqaThQFIq6bWPnj7L/ZWPh0ymldYFFyh8XdF0ywTgafsofDNYT4StlNknbaTjVHBma3SNjQ=="
+    },
+    "@mui/icons-material": {
+      "version": "5.14.8",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.14.8.tgz",
+      "integrity": "sha512-YXcReLydTuNWb1/PxduAH5LgnHNH6spSQBaA0JOz9HD4J+vwst0IanAQgsXy9KKCJSjCsHywE3DB8X+w/b4eeQ==",
+      "requires": {
+        "@babel/runtime": "^7.22.10"
+      }
     },
     "@mui/material": {
-      "version": "5.14.4",
-      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.14.4.tgz",
-      "integrity": "sha512-2XUV3KyRC07BQPPzEgd+ss3x/ezXtHeKtOGCMCNmx3MauZojPYUpSwFkE0fYgYCD9dMQMVG4DY/VF38P0KShsg==",
+      "version": "5.14.8",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.14.8.tgz",
+      "integrity": "sha512-fqvDGGF1pXwOOL/f0Gw+KHo/67hasRpf2ApTIJkbuONOk9AUb2jnYMEqCWmL2sUcbbE3ShMbHl8N7HPSsRv1/A==",
       "requires": {
-        "@babel/runtime": "^7.22.6",
-        "@mui/base": "5.0.0-beta.10",
-        "@mui/core-downloads-tracker": "^5.14.4",
-        "@mui/system": "^5.14.4",
+        "@babel/runtime": "^7.22.10",
+        "@mui/base": "5.0.0-beta.14",
+        "@mui/core-downloads-tracker": "^5.14.8",
+        "@mui/system": "^5.14.8",
         "@mui/types": "^7.2.4",
-        "@mui/utils": "^5.14.4",
+        "@mui/utils": "^5.14.8",
         "@types/react-transition-group": "^4.4.6",
         "clsx": "^2.0.0",
         "csstype": "^3.1.2",
@@ -22213,36 +22325,36 @@
       }
     },
     "@mui/private-theming": {
-      "version": "5.14.4",
-      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.14.4.tgz",
-      "integrity": "sha512-ISXsHDiQ3z1XA4IuKn+iXDWvDjcz/UcQBiFZqtdoIsEBt8CB7wgdQf3LwcwqO81dl5ofg/vNQBEnXuKfZHrnYA==",
+      "version": "5.14.8",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.14.8.tgz",
+      "integrity": "sha512-iBzpcl3Mh92XaYpYPdgzzRxNGkjpoDz8rf8/q5m+EBPowFEHV+CCS9hC0Q2pOKLW3VFFikA7w/GHt7n++40JGQ==",
       "requires": {
-        "@babel/runtime": "^7.22.6",
-        "@mui/utils": "^5.14.4",
+        "@babel/runtime": "^7.22.10",
+        "@mui/utils": "^5.14.8",
         "prop-types": "^15.8.1"
       }
     },
     "@mui/styled-engine": {
-      "version": "5.13.2",
-      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.13.2.tgz",
-      "integrity": "sha512-VCYCU6xVtXOrIN8lcbuPmoG+u7FYuOERG++fpY74hPpEWkyFQG97F+/XfTQVYzlR2m7nPjnwVUgATcTCMEaMvw==",
+      "version": "5.14.8",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.14.8.tgz",
+      "integrity": "sha512-LGwOav/Y40PZWZ2yDk4beUoRlc57Vg+Vpxi9V9BBtT2ESAucCgFobkt+T8eVLMWF9huUou5pwKgLSU5pF90hBg==",
       "requires": {
-        "@babel/runtime": "^7.21.0",
+        "@babel/runtime": "^7.22.10",
         "@emotion/cache": "^11.11.0",
         "csstype": "^3.1.2",
         "prop-types": "^15.8.1"
       }
     },
     "@mui/system": {
-      "version": "5.14.4",
-      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.14.4.tgz",
-      "integrity": "sha512-oPgfWS97QNfHcDBapdkZIs4G5i85BJt69Hp6wbXF6s7vi3Evcmhdk8AbCRW6n0sX4vTj8oe0mh0RIm1G2A1KDA==",
+      "version": "5.14.8",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.14.8.tgz",
+      "integrity": "sha512-Dxnasv7Pj5hYe4ZZFKJZu4ufKm6cxpitWt3A+qMPps22YhqyeEqgDBq/HsAB3GOjqDP40fTAvQvS/Hguf4SJuw==",
       "requires": {
-        "@babel/runtime": "^7.22.6",
-        "@mui/private-theming": "^5.14.4",
-        "@mui/styled-engine": "^5.13.2",
+        "@babel/runtime": "^7.22.10",
+        "@mui/private-theming": "^5.14.8",
+        "@mui/styled-engine": "^5.14.8",
         "@mui/types": "^7.2.4",
-        "@mui/utils": "^5.14.4",
+        "@mui/utils": "^5.14.8",
         "clsx": "^2.0.0",
         "csstype": "^3.1.2",
         "prop-types": "^15.8.1"
@@ -22255,11 +22367,11 @@
       "requires": {}
     },
     "@mui/utils": {
-      "version": "5.14.4",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.14.4.tgz",
-      "integrity": "sha512-4ANV0txPD3x0IcTCSEHKDWnsutg1K3m6Vz5IckkbLXVYu17oOZCVUdOKsb/txUmaCd0v0PmSRe5PW+Mlvns5dQ==",
+      "version": "5.14.8",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.14.8.tgz",
+      "integrity": "sha512-1Ls2FfyY2yVSz9NEqedh3J8JAbbZAnUWkOWLE2f4/Hc4T5UWHMfzBLLrCqExfqyfyU+uXYJPGeNIsky6f8Gh5Q==",
       "requires": {
-        "@babel/runtime": "^7.22.6",
+        "@babel/runtime": "^7.22.10",
         "@types/prop-types": "^15.7.5",
         "@types/react-is": "^18.2.1",
         "prop-types": "^15.8.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "dependencies": {
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
-    "@mui/material": "^5.14.4",
+    "@mui/icons-material": "^5.14.8",
+    "@mui/material": "^5.14.8",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",

--- a/src/components/DecidePrefecture.jsx
+++ b/src/components/DecidePrefecture.jsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { useChatGpt } from './../hooks/useChatGpt';
 import { useDecidePrefecture } from './../hooks/useDecidePrefecture';
 import { StartStopButton } from './StartStopButton';
+import { Loading } from './Loading';
 import styles from './DecidePrefecture.module.css';
 
 export const DecidePrefecture = () => {
@@ -54,8 +55,8 @@ export const DecidePrefecture = () => {
         />
       </div>
       <h1>あなたが行くのは{shuffledPrefectures[currentImageIndex] && shuffledPrefectures[currentImageIndex].kanji}</h1>
+      {isLoading && <Loading />}
       <p>{text && text}</p>
-      {isLoading ? 'ロード中...' : ''}
       <div className={styles.buttonContainer}>
         <StartStopButton handleClick={handleStopClick} text="STOP" />
       </div>

--- a/src/components/DecidePrefecture.jsx
+++ b/src/components/DecidePrefecture.jsx
@@ -1,11 +1,12 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useChatGpt } from './../hooks/useChatGpt';
 import { useDecidePrefecture } from './../hooks/useDecidePrefecture';
 import { StartStopButton } from './StartStopButton';
 import styles from './DecidePrefecture.module.css';
 
 export const DecidePrefecture = () => {
-  const [text, getReply] = useChatGpt();
+  const [isLoading, setIsLoading] = useState(false);
+  const [text, setText, getReply] = useChatGpt();
   const [
     currentImageIndex,
     isAnimating,
@@ -28,12 +29,20 @@ export const DecidePrefecture = () => {
       startAnimation();
     } else {
       stopAnimation();
-      getReply(shuffledPrefectures[currentImageIndex].romaji);
+      getReply(shuffledPrefectures[currentImageIndex].romaji)
+        .then((reply) => setText(reply))
+        .catch((error) => setText('APIリクエスト中にエラーが発生しました。')) // TODO: エラー発生時のUIを表現するものを考える。例：isErrorのstateを用意してtrueにするとエラー表示のコンポーネントが表示されるようにするとか)
+        .finally(() => setIsLoading(false));
     }
     return () => stopAnimation();
   }, [isAnimating]);
 
-  const handleStopClick = () => setIsAnimating(false);
+  const handleStopClick = () => {
+    if (text) return;
+
+    setIsAnimating(false);
+    setIsLoading(true);
+  };
 
   return (
     <>
@@ -46,6 +55,7 @@ export const DecidePrefecture = () => {
       </div>
       <h1>あなたが行くのは{shuffledPrefectures[currentImageIndex] && shuffledPrefectures[currentImageIndex].kanji}</h1>
       <p>{text && text}</p>
+      {isLoading ? 'ロード中...' : ''}
       <div className={styles.buttonContainer}>
         <StartStopButton handleClick={handleStopClick} text="STOP" />
       </div>

--- a/src/components/Loading.jsx
+++ b/src/components/Loading.jsx
@@ -1,0 +1,22 @@
+import { LinearProgress } from '@mui/material';
+import { createTheme, ThemeProvider } from '@mui/material/styles';
+import styles from './Loading.module.css';
+
+const theme = createTheme({
+  palette: {
+    primary: {
+      main: '#FE6561',
+    },
+  },
+});
+
+export const Loading = () => {
+  return (
+    <div>
+      <p className={styles.loadingText}>おすすめスポット生成中...</p>
+      <ThemeProvider theme={theme}>
+        <LinearProgress />
+      </ThemeProvider>
+    </div>
+  );
+};

--- a/src/components/Loading.module.css
+++ b/src/components/Loading.module.css
@@ -1,0 +1,3 @@
+.loadingText {
+  text-align: center;
+}

--- a/src/components/StartStopButton.jsx
+++ b/src/components/StartStopButton.jsx
@@ -1,8 +1,10 @@
 import Button from '@mui/material/Button';
+import PlaceIcon from '@mui/icons-material/Place';
 
 export const StartStopButton = (props) => {
   return (
     <Button variant="contained" onClick={props.handleClick}>
+      <PlaceIcon fontSize="small" />
       {props.text}
     </Button>
   );

--- a/src/hooks/useChatGpt.js
+++ b/src/hooks/useChatGpt.js
@@ -6,15 +6,12 @@ export const useChatGpt = () => {
 
   const getReply = async (prefecture) => {
     try {
-      setText('ローディング中...'); // 仮で文字列にしておく。TODO：booleanの状態変化するuseStateを実装してローディングのコンポーネントをtrue/falseで表示するようにする
       const client = new Client(prefecture);
-      const response = await client.execute();
-      setText(response);
+      return await client.execute();
     } catch (error) {
-      setText('APIリクエスト中にエラーが発生しました。'); // TODO: エラー発生時のUIを表現するものを考える。例：isErrorのstateを用意してtrueにするとエラー表示のコンポーネントが表示されるようにするとか
-      console.error(error);
+      throw new Error(error);
     }
   };
 
-  return [text, getReply];
+  return [text, setText, getReply];
 };

--- a/src/hooks/useDecidePrefecture.js
+++ b/src/hooks/useDecidePrefecture.js
@@ -27,8 +27,6 @@ export const useDecidePrefecture = () => {
         return prevIndex + 1;
       });
     }, 50);
-
-    return () => clearInterval(animationInterval);
   };
 
   const stopAnimation = () => clearInterval(animationInterval);

--- a/src/mocks/browser.js
+++ b/src/mocks/browser.js
@@ -17,7 +17,7 @@ export const worker = setupWorker(
 
     return res(
       ctx.status(200),
-      ctx.delay(1000),
+      ctx.delay(2000),
       ctx.json({
         content: `
           ${prefecture.kanji}の説明だよ〜〜〜〜。${prefecture.kanji}の説明だよ〜〜〜〜。


### PR DESCRIPTION
## 概要
- apiにリクエストを投げている最中のローディング状態を表現するUIの実装と、それに伴うリファクタリング
- ボタンにマップアイコンを追加

## 対応の詳細
- ボタンにmuiから持ってきたアイコンを追加 https://mui.com/material-ui/material-icons/?query=location&selected=Place
- setTextをコンポーネント側で利用するようにした
  - 「ローディング中...」と、エラーが起きた時の「APIリクエスト中にエラーが発生しました。」の表示を管理するのは、リクエスト関数（getReply）ではなく、コンポーネント側の方が適切だと思ったため
- loadingのstateを定義して、リクエスト中のロードのUIを実装
- その他細かいリファクタリング

## 動作確認
- git fetchしてこのブランチを持ってきてからcheckoutしてもらい、npm install（アイコンとかのインストールです）
- ボタンを押して確認

## レビュー観点
これもコミット順で見ると分かりやすいかもです
https://github.com/Apocalyptic-Wonderboiled/wonder-app/pull/34/commits

- ロードのUIをクルクルではなく、Progressバーにしたが問題なさそうか（色はデザインにあるボタンの色味に合わせてます）
  - クルクルだと少し小さくて視認しづらいかなと思ったのでこちらにしました。

Progressの場合（今の実装）

https://github.com/Apocalyptic-Wonderboiled/wonder-app/assets/63830279/db3b92bc-aad9-4693-9f09-e26be645148e


クルクルの場合

https://github.com/Apocalyptic-Wonderboiled/wonder-app/assets/63830279/d27e4619-fa0c-4674-b005-bea21859a850


## その他
<!-- レビュワーへの参考情報（実装上の懸念点や注意点などあれば記載） -->