### PR TITLE
apiでエラーが起きた時用のアラートの表示

### DIFF
--- a/src/components/DecidePrefecture.jsx
+++ b/src/components/DecidePrefecture.jsx
@@ -4,9 +4,11 @@ import { useDecidePrefecture } from './../hooks/useDecidePrefecture';
 import { StartStopButton } from './StartStopButton';
 import { Loading } from './Loading';
 import styles from './DecidePrefecture.module.css';
+import { ErrorAlert } from './ErrorAlert';
 
 export const DecidePrefecture = () => {
   const [isLoading, setIsLoading] = useState(false);
+  const [isError, setIsError] = useState(false);
   const [text, setText, getReply] = useChatGpt();
   const [
     currentImageIndex,
@@ -32,7 +34,7 @@ export const DecidePrefecture = () => {
       stopAnimation();
       getReply(shuffledPrefectures[currentImageIndex].romaji)
         .then((reply) => setText(reply))
-        .catch((error) => setText('APIリクエスト中にエラーが発生しました。')) // TODO: エラー発生時のUIを表現するものを考える。例：isErrorのstateを用意してtrueにするとエラー表示のコンポーネントが表示されるようにするとか)
+        .catch((error) => setIsError(true))
         .finally(() => setIsLoading(false));
     }
     return () => stopAnimation();
@@ -56,6 +58,7 @@ export const DecidePrefecture = () => {
       </div>
       <h1>あなたが行くのは{shuffledPrefectures[currentImageIndex] && shuffledPrefectures[currentImageIndex].kanji}</h1>
       {isLoading && <Loading />}
+      {isError && <ErrorAlert text="おすすめスポットの取得ができませんでした。もう一度お試しください。" />}
       <p>{text && text}</p>
       <div className={styles.buttonContainer}>
         <StartStopButton handleClick={handleStopClick} text="STOP" />

--- a/src/components/ErrorAlert.jsx
+++ b/src/components/ErrorAlert.jsx
@@ -1,0 +1,10 @@
+import { Alert, AlertTitle } from '@mui/material';
+
+export const ErrorAlert = (props) => {
+  return (
+    <Alert severity="error">
+      <AlertTitle>Error</AlertTitle>
+      {props.text}
+    </Alert>
+  );
+};


### PR DESCRIPTION
## 概要
掲題の通り

## 対応の詳細
- muiのAlertコンポーネントを使用したAlertErrorコンポーネントを作成
  - エラー表示はapiリクエスト時くらいしかユースケースはなさそうなのでそんなに汎用的なものにはしてません

## レビュー観点
エラー時の文言とか、これで良さそう？

## 動作確認
- `wonder-app/src/mocks/browser.js`のレスポンス返却値を下記のように修正すればエラーが返るようになるので確認できるはず https://github.com/Apocalyptic-Wonderboiled/wonder-app/blob/develop/src/mocks/browser.js#L19
```js
export const worker = setupWorker(
  rest.post('/v1/chat/completions', (req, res, ctx) => {

  ・・・中略・・・

    return res(
      ctx.status(200), ←ここを500に変えるだけ
      ctx.delay(2000),
      ctx.json({
        content: `
          ${prefecture.kanji}の説明だよ〜〜〜〜。${prefecture.kanji}の説明だよ〜〜〜〜。
          ${prefecture.kanji}の説明だよ〜〜〜〜。${prefecture.kanji}の説明だよ〜〜〜〜。
          ${prefecture.kanji}の説明だよ〜〜〜〜。${prefecture.kanji}の説明だよ〜〜〜〜。
          ${prefecture.kanji}の説明だよ〜〜〜〜。${prefecture.kanji}の説明だよ〜〜〜〜。
          ${prefecture.kanji}の説明だよ〜〜〜〜。${prefecture.kanji}の説明だよ〜〜〜〜。
          ${prefecture.kanji}の説明だよ〜〜〜〜。${prefecture.kanji}の説明だよ〜〜〜〜。
          ${prefecture.kanji}の説明だよ〜〜〜〜。${prefecture.kanji}の説明だよ〜〜〜〜。
          ${prefecture.kanji}の説明だよ〜〜〜〜。${prefecture.kanji}の説明だよ〜〜〜〜。
          ${prefecture.kanji}の説明だよ〜〜〜〜。${prefecture.kanji}の説明だよ〜〜〜〜。
          ${prefecture.kanji}の説明だよ〜〜〜〜。${prefecture.kanji}の説明だよ〜〜〜〜。
          ${prefecture.kanji}の説明だよ〜〜〜〜。${prefecture.kanji}の説明だよ〜〜〜〜。
          ${prefecture.kanji}の説明だよ〜〜〜〜。${prefecture.kanji}の説明だよ〜〜〜〜。
          ${prefecture.kanji}の説明だよ〜〜〜〜。${prefecture.kanji}の説明だよ〜〜〜〜。
          ${prefecture.kanji}の説明だよ〜〜〜〜。${prefecture.kanji}の説明だよ〜〜〜〜。
        `,
      }),
    );
  }),
);
```

## イメージ

https://github.com/Apocalyptic-Wonderboiled/wonder-app/assets/63830279/38b72061-cbd6-4a6a-8e23-58e5233fee5e

